### PR TITLE
修复字节码注入类忽略mocker的逻辑synthetic

### DIFF
--- a/src/main/java/com/github/jsonzou/jmockdata/mocker/BeanMocker.java
+++ b/src/main/java/com/github/jsonzou/jmockdata/mocker/BeanMocker.java
@@ -55,14 +55,14 @@ public class BeanMocker implements Mocker<Object> {
     for (Class<?> currentClass = clazz; currentClass != Object.class; currentClass = currentClass.getSuperclass()) {
       // 模拟有setter方法的字段
       for (Field field :currentClass.getDeclaredFields()) {
-        if (field.isAnnotationPresent(MockIgnore.class)) {
+        if (field.isAnnotationPresent(MockIgnore.class) || field.isSynthetic()) {
           continue;
         }
 
         if (field.getName() != null && field.getName().equalsIgnoreCase("serialVersionUID")) {
           continue;
         }
-        
+
         /**
          * 是否配置排除这个属性
          */
@@ -87,22 +87,22 @@ public class BeanMocker implements Mocker<Object> {
       // 模拟有setter方法的字段
       for (Entry<Field, Method> entry : ReflectionUtils.fieldAndSetterMethod(currentClass).entrySet()) {
         Field field = entry.getKey();
-        if (field.isAnnotationPresent(MockIgnore.class)) {
+        if (field.isAnnotationPresent(MockIgnore.class) || field.isSynthetic()) {
           continue;
         }
-        
+
         if (field.getName() != null && field.getName().equalsIgnoreCase("serialVersionUID")) {
           continue;
         }
-        
+
         /**
          * 是否配置排除这个属性
          */
         if(mockConfig.globalConfig().isConfigExcludeMock(clazz,field.getName())){
-           continue;
+          continue;
         }
         ReflectionUtils
-            .setRefValue(result, entry.getValue(), new BaseMocker(field.getGenericType()).mock(mockConfig.globalConfig().getDataConfig(currentClass,field.getName())));
+                .setRefValue(result, entry.getValue(), new BaseMocker(field.getGenericType()).mock(mockConfig.globalConfig().getDataConfig(currentClass,field.getName())));
       }
     }
   }

--- a/src/main/java/com/github/jsonzou/jmockdata/mocker/EnumMocker.java
+++ b/src/main/java/com/github/jsonzou/jmockdata/mocker/EnumMocker.java
@@ -1,37 +1,35 @@
 package com.github.jsonzou.jmockdata.mocker;
 
 import com.github.jsonzou.jmockdata.DataConfig;
-import com.github.jsonzou.jmockdata.MockConfig;
 import com.github.jsonzou.jmockdata.MockException;
 import com.github.jsonzou.jmockdata.Mocker;
 import com.github.jsonzou.jmockdata.util.RandomUtils;
-import java.lang.reflect.Field;
 
 /**
  * Enum对象模拟器
  */
 public class EnumMocker<T extends Enum> implements Mocker<Object> {
 
-  private Class<?> clazz;
+    private Class<?> clazz;
 
-  public EnumMocker(Class<?> clazz) {
-    this.clazz = clazz;
-  }
-
-  @Override
-  public T mock(DataConfig mockConfig) {
-
-    Enum[] enums = mockConfig.globalConfig().getcacheEnum(clazz.getName());
-    if (enums == null) {
-      //  Field field = clazz.getDeclaredField("$VALUES");
-       // field.setAccessible(true);
-        enums =(Enum[]) clazz.getEnumConstants();
-        if (enums.length == 0) {
-          throw new MockException("空的enum不能模拟");
-        }
-        mockConfig.globalConfig().cacheEnum(clazz.getName(), enums);
+    public EnumMocker(Class<?> clazz) {
+        this.clazz = clazz;
     }
-    return (T) enums[RandomUtils.nextInt(0, enums.length)];
-  }
+
+    @Override
+    public T mock(DataConfig mockConfig) {
+
+        Enum[] enums = mockConfig.globalConfig().getcacheEnum(clazz.getName());
+        if (enums == null) {
+            //  Field field = clazz.getDeclaredField("$VALUES");
+            // field.setAccessible(true);
+            enums =(Enum[]) clazz.getEnumConstants();
+            if (enums.length == 0) {
+                throw new MockException("空的enum不能模拟");
+            }
+            mockConfig.globalConfig().cacheEnum(clazz.getName(), enums);
+        }
+        return (T) enums[RandomUtils.nextInt(0, enums.length)];
+    }
 
 }

--- a/src/main/java/com/github/jsonzou/jmockdata/mocker/GenericMocker.java
+++ b/src/main/java/com/github/jsonzou/jmockdata/mocker/GenericMocker.java
@@ -1,7 +1,6 @@
 package com.github.jsonzou.jmockdata.mocker;
 
 import com.github.jsonzou.jmockdata.DataConfig;
-import com.github.jsonzou.jmockdata.MockConfig;
 import com.github.jsonzou.jmockdata.Mocker;
 import java.lang.reflect.ParameterizedType;
 
@@ -12,13 +11,13 @@ public class GenericMocker implements Mocker<Object> {
 
   private ParameterizedType type;
 
-  GenericMocker(ParameterizedType type) {
-    this.type = type;
-  }
-
   @Override
   public Object mock(DataConfig mockConfig) {
     return new BaseMocker(type.getRawType(), type.getActualTypeArguments()).mock(mockConfig);
+  }
+
+  GenericMocker(ParameterizedType type) {
+    this.type = type;
   }
 
 }

--- a/src/main/java/com/github/jsonzou/jmockdata/util/ReflectionUtils.java
+++ b/src/main/java/com/github/jsonzou/jmockdata/util/ReflectionUtils.java
@@ -54,6 +54,9 @@ public final class ReflectionUtils {
     BeanInfo beanInfo = Introspector.getBeanInfo(clazz, Object.class);
     PropertyDescriptor[] propertyDescriptors = beanInfo.getPropertyDescriptors();
     for (Field field : clazz.getDeclaredFields()) {
+      if (field.isSynthetic()){
+        continue;
+      }
       for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {
         if (propertyDescriptor.getName().equals(field.getName()) && propertyDescriptor.getWriteMethod() != null) {
           map.put(field, propertyDescriptor.getWriteMethod());


### PR DESCRIPTION
在Jvm代理类中synthetic标识的类为JVM注入属性，不需要mockdata处理